### PR TITLE
tweaks paths

### DIFF
--- a/CentOS-Ceph-Hammer.repo
+++ b/CentOS-Ceph-Hammer.repo
@@ -19,14 +19,14 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
 
 [centos-ceph-hammer-debuginfo]
 name=CentOS-$releasever - Ceph Hammer DebugInfo
-baseurl=http://debuginfo.centos.org/centos/$releasever/storage/$basearch/ceph-hammer/
-gpgcheck=0
+baseurl=http://debuginfo.centos.org/centos/$releasever/storage/$basearch/
+gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
 
 [centos-ceph-hammer-source]
 name=CentOS-$releasever - Ceph Hammer Source
 baseurl=http://vault.centos.org/centos/$releasever/storage/Source/ceph-hammer/
-gpgcheck=0
+gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage


### PR DESCRIPTION
The debug and srpms are signed, so we can safely turn on the gpgcheck. 

Also, the debugs are dropped into a common directory for all the storage sig ( this is for all SIGs ), rather than split them by project name. The assumption being that there will never be the same rpm ( name-version-release.arch ) from two different projects in the same SIG ( they should just tag each others content as needed ).
